### PR TITLE
feat(frontend): add reusable ImageSection component

### DIFF
--- a/frontend/src/components/ImageSection.tsx
+++ b/frontend/src/components/ImageSection.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { fetchImageSection } from "../lib/api";
+
+type ImageItem = {
+  id: number;
+  image_url: string;
+  alt_text?: string | null;
+  link_url?: string | null;
+};
+
+type ImageSectionProps = {
+  locale: "en" | "zh";
+  sectionKey: string;
+};
+
+export default function ImageSection({
+  locale,
+  sectionKey,
+}: ImageSectionProps) {
+  const [images, setImages] = useState<ImageItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchImageSection(locale, sectionKey)
+      .then((data) => {
+        setImages(data.images || []);
+        setError(null);
+      })
+      .catch(() => {
+        setError("Failed to load images");
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [locale, sectionKey]);
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>{error}</p>;
+  if (!images.length) return null;
+
+  return (
+    <div className="image-section">
+      {images.map((img) => {
+        const imageEl = (
+          <img
+            src={img.image_url}
+            alt={img.alt_text || ""}
+            style={{ width: "100%", height: "auto" }}
+          />
+        );
+
+        return (
+          <div key={img.id} className="image-item">
+            {img.link_url ? (
+              <a href={img.link_url} target="_blank" rel="noreferrer">
+                {imageEl}
+              </a>
+            ) : (
+              imageEl
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -32,3 +32,44 @@ export async function fetchAdminEmails(username: string, password: string) {
   console.log("api.ts data:", data);
   return data;
 }
+
+export type ImageItem = {
+  id: number;
+  image_url: string;
+  alt_text?: string | null;
+  link_url?: string | null;
+  is_hidden?: boolean;
+  sort_order?: number;
+};
+
+export type ImageSectionResponse = {
+  section?: {
+    id?: number;
+    key?: string;
+    locale?: string;
+    is_enabled?: boolean;
+  };
+  images: ImageItem[];
+};
+
+export async function fetchImageSection(
+  locale: string,
+  sectionKey: string,
+  includeHidden = false
+): Promise<ImageSectionResponse> {
+  const params = new URLSearchParams();
+  if (includeHidden) params.set("include_hidden", "true");
+
+  const url =
+    `${API_BASE}/api/content/${encodeURIComponent(locale)}/${encodeURIComponent(sectionKey)}` +
+    (params.toString() ? `?${params.toString()}` : "");
+
+  const res = await fetch(url);
+
+  if (!res.ok) {
+    const msg = await res.text().catch(() => "");
+    throw new Error(msg || "Failed to fetch image section");
+  }
+
+  return res.json();
+}

--- a/frontend/src/pages/OurValuePage.tsx
+++ b/frontend/src/pages/OurValuePage.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Navbar } from "../components/Navbar";
 import { Footer } from "../components/Footer";
+import ImageSection from "../components/ImageSection";
+
 
 export function OurValuePage() {
   const [visibleSections, setVisibleSections] = useState<Set<number>>(new Set());
@@ -58,6 +60,13 @@ export function OurValuePage() {
           </div>
         </section>
 
+        {/* Our Business Image Section */}
+        <section className="w-full bg-black px-6 py-12">
+          <div className="mx-auto max-w-6xl">
+            <ImageSection locale="en" sectionKey="our_business" />
+          </div>
+        </section>
+        
         {/* Content Section */}
         <section className="w-full bg-black px-6 py-12 pb-20">
           <div className="mx-auto max-w-6xl space-y-8">


### PR DESCRIPTION
## Summary
This PR adds a reusable `ImageSection` React component that renders image blocks dynamically from backend data.

## What’s included
- New `ImageSection` component under `src/components`
- Fetches image data from `/api/content/{locale}/{section_key}`
- Supports image ordering, hide/show, alt text, and optional links
- Integrated on the Our Value page as the first usage example

## Notes
- Placeholder images are used temporarily until real assets are provided
- No hardcoded image paths in page components
- Designed to be reused across multiple pages

## Scope
- Frontend only
- No admin UI included
